### PR TITLE
 Add ability to declare some attributes as loosly validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.0
 
- - Add ability to define multiple versions using one block
+ - Add ability to define multiple versions using one block.
+ - Added ability to mark certain attributes as optional when validating with `loose: true` and required otherwise.
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+ - Add ability to define multiple versions using one block
+
 ## 2.1.1
 
 - Fix Ruby 2.6 to 2.7 incompatible change

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ class Venue
     
     version 1 do
       attribute :name, String
-      attribute :coords, String
+      attribute :coords, String, optional: :loose
       attribute :updated_at, String
     
       link :self
@@ -467,8 +467,8 @@ class MyMedia
     { "foo": { "bar": "string" } }
     FIXTURE
     assert_fail '{"foo": {}}'
-    assert_fail '{"foo": null}'
-    assert_fail '{"foo": [42]}'
+    assert_fail '{"foo": null}', loose: true
+    assert_fail '{"foo": [42]}', loose: false
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ class Venue
         attribute :altitude, AllowNil(Numeric)
       end
       
-      version 1 do
+      versions [1, 2] do |v|
         collection :location do
+          link :extra if v > 1
+          
           attribute :latitude, Numeric
           attribute :longitude, Numeric
           attribute :altitude, AllowNil(Numeric)

--- a/lib/media_types/constructable.rb
+++ b/lib/media_types/constructable.rb
@@ -125,6 +125,7 @@ module MediaTypes
     end
 
     def validatable?
+      return false if media_type_combinations.nil?
       return false unless media_type_combinations.include? as_key
 
       __getobj__.validatable?(self)

--- a/lib/media_types/scheme.rb
+++ b/lib/media_types/scheme.rb
@@ -51,13 +51,14 @@ module MediaTypes
   end
 
   class FixtureData
-    def initialize(caller:, fixture:, expect_to_pass:)
+    def initialize(caller:, fixture:, expect_to_pass:, loose:)
       self.caller = caller
       self.fixture = fixture
       self.expect_to_pass = expect_to_pass
+      self.loose = loose
     end
 
-    attr_accessor :caller, :fixture, :expect_to_pass
+    attr_accessor :caller, :fixture, :expect_to_pass, :loose
 
     alias expect_to_pass? expect_to_pass
   end
@@ -431,14 +432,14 @@ module MediaTypes
       ].join("\n")
     end
 
-    def assert_pass(fixture)
+    def assert_pass(fixture, loose: false)
       reduced_stack = remove_current_dir_from_stack(caller_locations)
-      @fixtures << FixtureData.new(caller: reduced_stack.first, fixture: fixture, expect_to_pass: true)
+      @fixtures << FixtureData.new(caller: reduced_stack.first, fixture: fixture, expect_to_pass: true, loose: loose)
     end
 
-    def assert_fail(fixture)
+    def assert_fail(fixture, loose: false)
       reduced_stack = remove_current_dir_from_stack(caller_locations)
-      @fixtures << FixtureData.new(caller: reduced_stack.first, fixture: fixture, expect_to_pass: false)
+      @fixtures << FixtureData.new(caller: reduced_stack.first, fixture: fixture, expect_to_pass: false, loose: loose)
     end
 
     # Removes all calls originating in current dir from given stack
@@ -496,7 +497,7 @@ module MediaTypes
       expected_key_type = expect_symbol_keys ? Symbol : String
 
       begin
-        validate(json, expected_key_type: expected_key_type, backtrace: backtrace)
+        validate(json, expected_key_type: expected_key_type, backtrace: backtrace, loose: fixture_data.loose)
         unless fixture_data.expect_to_pass?
           raise UnexpectedValidationResultError.new(fixture_data.caller, 'No error encounterd whilst expecting to')
         end

--- a/lib/media_types/scheme/output_empty_guard.rb
+++ b/lib/media_types/scheme/output_empty_guard.rb
@@ -29,15 +29,15 @@ module MediaTypes
       attr_accessor :output, :options, :rules
 
       def allow_empty?
-        rules.allow_empty? || rules.required.empty?
+        rules.allow_empty? || rules.required(loose: options.loose).empty?
       end
 
       def raise_empty!(backtrace:, found:)
         raise EmptyOutputError, format(
-          'Expected output, got empty at %<backtrace>s. Required are: %<required>s. Found: %<found>s',
+          'The object at %<backtrace>s was empty but I expected contents. Required keys are: %<required>s.',
           backtrace: backtrace.join('->'),
-          required: rules.required.keys,
-          found: (found.is_a? Hash) ? found.keys : found.class.name,
+          required: rules.required(loose: options.loose).keys,
+          found: (found.respond_to? :keys) ? found.keys : found.class.name,
         )
       end
     end

--- a/lib/media_types/scheme/rules_exhausted_guard.rb
+++ b/lib/media_types/scheme/rules_exhausted_guard.rb
@@ -26,7 +26,7 @@ module MediaTypes
           return iterate(EMPTY_MARK)
         end
 
-        required_rules = rules.required
+        required_rules = rules.required(loose: options.loose)
         # noinspection RubyScope
         result = iterate(->(key) { required_rules.remove(key) })
         return result if required_rules.empty?

--- a/lib/media_types/scheme/validation_options.rb
+++ b/lib/media_types/scheme/validation_options.rb
@@ -3,18 +3,19 @@
 module MediaTypes
   class Scheme
     class ValidationOptions
-      attr_accessor :exhaustive, :strict, :backtrace, :context, :expected_key_type
+      attr_accessor :exhaustive, :strict, :backtrace, :context, :expected_key_type, :loose
 
-      def initialize(context = {}, exhaustive: true, strict: true, backtrace: [], expected_key_type:)
+      def initialize(context = {}, exhaustive: true, strict: true, backtrace: [], loose: false, expected_key_type:)
         self.exhaustive = exhaustive
         self.strict = strict
         self.backtrace = backtrace
         self.context = context
         self.expected_key_type = expected_key_type
+        self.loose = loose
       end
 
       def inspect
-        "backtrack: #{backtrace.inspect}, strict: #{strict.inspect}, exhaustive: #{exhaustive}, current_obj: #{scoped_output.to_json}"
+        "backtrack: #{backtrace.inspect}, strict: #{strict.inspect}, loose: #{loose}, exhaustive: #{exhaustive}, current_obj: #{scoped_output.to_json}"
       end
 
       def scoped_output
@@ -28,7 +29,7 @@ module MediaTypes
       end
 
       def with_backtrace(backtrace)
-        ValidationOptions.new(context, exhaustive: exhaustive, strict: strict, backtrace: backtrace, expected_key_type: expected_key_type)
+        ValidationOptions.new(context, exhaustive: exhaustive, strict: strict, backtrace: backtrace, expected_key_type: expected_key_type, loose: loose)
       end
 
       def trace(*traces)
@@ -36,7 +37,7 @@ module MediaTypes
       end
 
       def exhaustive!
-        ValidationOptions.new(context, exhaustive: true, strict: strict, backtrace: backtrace, expected_key_type: expected_key_type)
+        ValidationOptions.new(context, exhaustive: true, strict: strict, backtrace: backtrace, expected_key_type: expected_key_type, loose: loose)
       end
     end
   end

--- a/lib/media_types/validations.rb
+++ b/lib/media_types/validations.rb
@@ -90,6 +90,19 @@ module MediaTypes
     end
 
     ##
+    # Runs the block for multiple versions
+    #
+    # @param [Array] list of versions to run this on
+    #
+    def versions(versions, &block)
+      versions.each do |v|
+        Validations.new(media_type.version(v), registry) do
+          block(v)
+        end
+      end
+    end
+
+    ##
     # Switches the inner block to a specific view
     #
     # @param [String, Symbol] view the view to switch to

--- a/test/media_types/loose_validation_test.rb
+++ b/test/media_types/loose_validation_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LooseValidationTest < Minitest::Test
+  ### Attribute ###
+
+  class TestLooseAttributes
+    include MediaTypes::Dsl
+
+    def self.organisation
+      'domain.test'
+    end
+
+    use_name 'TestThatWholeContextOfBlockIsUsedAttribute'
+
+    # default attribute (=hash object)
+    validations do
+      attribute :foo do
+        attribute :bar, Numeric, optional: :loose
+      end
+      assert_pass '{"foo":{}}', loose: true
+      assert_fail '{"foo":{}}', loose: false
+    end
+  end
+
+  [TestLooseAttributes].each do |type|
+    create_specification_tests_for type
+  end
+end


### PR DESCRIPTION
Allows skipping certain attributes when the loose argument is set.
Fixes #143 