### PR TITLE
Add helper methods for use with serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@
 .idea/
 
 /media_types-*.gem
+/media-types-*.tar.gz
+/ruby-media-types-*
+/ruby-media-types_*.deb
+/ruby-media-types_*.buildinfo
+/ruby-media-types_*.changes
+/ruby-media-types_*.debian.tar.xz
+/ruby-media-types_*.dsc
+/ruby-media-types_*.orig.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  - Add ability to define multiple versions using one block.
  - Added ability to mark certain attributes as optional when validating with `loose: true` and required otherwise.
+ - Added `index` attribute type that automatically generates a link list compatible with media_types-serialization.
+ - Added support for `collection` to automatically look up a previously defined schema when passing a view.
 
 ## 2.1.1
 

--- a/lib/media_types/errors.rb
+++ b/lib/media_types/errors.rb
@@ -15,5 +15,11 @@ module MediaTypes
         super(format('Unable to change key type expectation for %<mod>s since its current expectation is already used', mod: mod.name))
       end
     end
+
+    class CollectionDefinitionNotFound < StandardError
+      def initialize(current, target)
+        super(format('Unable to use %<target>s as a collection inside %<current>s, no such schema has been defined.', current: current, target: target))
+      end
+    end
   end
 end

--- a/lib/media_types/validations.rb
+++ b/lib/media_types/validations.rb
@@ -25,7 +25,7 @@ module MediaTypes
     # @see Constructable
     # @see Scheme
     #
-    def initialize(media_type, registry = {}, scheme = Scheme.new, &block)
+    def initialize(media_type, registry = {}, scheme = Scheme.new(registry: registry, current_type: media_type), &block)
       self.media_type = media_type
       self.registry = registry.merge!(media_type.as_key => scheme)
       self.scheme = scheme

--- a/test/media_types/dsl/collection_test.rb
+++ b/test/media_types/dsl/collection_test.rb
@@ -305,6 +305,33 @@ module MediaTypes
         end
       end
 
+      
+      class IndexCollectionType
+        include MediaTypes::Dsl
+
+        def self.organisation
+          'acme'
+        end
+
+        use_name 'index_test'
+
+        validations do
+          version 1 do
+            attribute :bar, Numeric
+          end
+
+          view :index do
+            version 1 do
+              collection :_embedded
+            end
+          end
+        end
+      end
+
+      def test_index_collections
+        assert IndexCollectionType.view(:index).version(1).validate!({ _embedded: [{ bar: 42 }] }), 'Expected input to be valid'
+      end
+
     end
   end
 end


### PR DESCRIPTION
 - Added `index` attribute type that automatically generates a link list compatible with media_types-serialization.
 - Added support for `collection` to automatically look up a previously defined schema when passing a view.